### PR TITLE
Test output expectations should fail if the process has prematurely exited.

### DIFF
--- a/expect.go
+++ b/expect.go
@@ -180,7 +180,7 @@ func (tt *TermTest) expectExitCode(exitCode int, match bool, opts ...SetExpectOp
 	select {
 	case <-time.After(timeoutV):
 		return fmt.Errorf("after %s: %w", timeoutV, TimeoutError)
-	case state := <-ttExited(tt, false):
+	case state := <-tt.Exited(false): // do not wait for unread output since it's not read by this select{}
 		if state.Err != nil && (state.ProcessState == nil || state.ProcessState.ExitCode() == 0) {
 			return fmt.Errorf("cmd wait failed: %w", state.Err)
 		}

--- a/helpers.go
+++ b/helpers.go
@@ -18,9 +18,6 @@ var neverGonnaHappen = time.Hour * 24 * 365 * 100
 var lineSepPosix = "\n"
 var lineSepWindows = "\r\n"
 
-var processExitPollInterval = 10 * time.Millisecond
-var processExitExtraWait = 500 * time.Millisecond
-
 type cmdExit struct {
 	ProcessState *os.ProcessState
 	Err          error
@@ -34,27 +31,6 @@ func waitForCmdExit(cmd *exec.Cmd) chan *cmdExit {
 		exit <- &cmdExit{ProcessState: cmd.ProcessState, Err: err}
 	}()
 	return exit
-}
-
-// ttExited returns a channel that sends the given termtest's command cmdExit info when available.
-// This can be used within a select{} statement.
-// If waitExtra is given, waits a little bit before sending cmdExit info. This allows any fellow
-// switch cases to handle unprocessed stdout.
-func ttExited(tt *TermTest, waitExtra bool) chan *cmdExit {
-	return waitChan(func() *cmdExit {
-		ticker := time.NewTicker(processExitPollInterval)
-		for {
-			select {
-			case <-ticker.C:
-				if tt.exited != nil {
-					if waitExtra {
-						time.Sleep(processExitExtraWait)
-					}
-					return tt.exited
-				}
-			}
-		}
-	})
 }
 
 func waitChan[T any](wait func() T) chan T {

--- a/outputconsumer.go
+++ b/outputconsumer.go
@@ -103,7 +103,7 @@ func (e *outputConsumer) wait() error {
 		e.mutex.Lock()
 		e.opts.Logger.Println("Encountered timeout")
 		return fmt.Errorf("after %s: %w", e.opts.Timeout, TimeoutError)
-	case state := <-ttExited(e.tt, true):
+	case state := <-e.tt.Exited(true): // allow for output to be read first by first case in this select{}
 		e.mutex.Lock()
 		if state.Err != nil {
 			e.opts.Logger.Println("Encountered error waiting for process to exit: %s\n", state.Err.Error())

--- a/outputproducer.go
+++ b/outputproducer.go
@@ -238,12 +238,12 @@ func (o *outputProducer) flushConsumers() error {
 	return nil
 }
 
-func (o *outputProducer) addConsumer(consume consumer, opts ...SetConsOpt) (*outputConsumer, error) {
+func (o *outputProducer) addConsumer(tt *TermTest, consume consumer, opts ...SetConsOpt) (*outputConsumer, error) {
 	o.opts.Logger.Printf("adding consumer")
 	defer o.opts.Logger.Printf("added consumer")
 
 	opts = append(opts, OptConsInherit(o.opts))
-	listener := newOutputConsumer(consume, opts...)
+	listener := newOutputConsumer(tt, consume, opts...)
 	o.consumers = append(o.consumers, listener)
 
 	if err := o.flushConsumers(); err != nil {

--- a/termtest.go
+++ b/termtest.go
@@ -24,6 +24,7 @@ type TermTest struct {
 	outputProducer *outputProducer
 	listenError    chan error
 	opts           *Opts
+	exited         *cmdExit
 }
 
 type ErrorHandler func(*TermTest, error) error
@@ -233,6 +234,10 @@ func (tt *TermTest) start() (rerr error) {
 		tt.listenError <- err
 	}()
 	wg.Wait()
+
+	go func() {
+		tt.exited = <-waitForCmdExit(tt.cmd)
+	}()
 
 	return nil
 }


### PR DESCRIPTION
The idea is to call `exec.Cmd.Wait()` in a goroutine (https://github.com/ActiveState/termtest/pull/12/files#diff-13ff3d9e77d1ebdf70d066552cb9e504472550dc97fd74aac53a8ab3a63e54a1) and edit the Expect() functions (https://github.com/ActiveState/termtest/pull/12/files#diff-a63ecf8315eeb0943ebec69499243bd650ae6b99635bde7aa1c0f6ac773368c2R106-R111 and https://github.com/ActiveState/termtest/pull/12/files#diff-2a74ac0f372490e4a5cf19a11e38b9329713643dc44c65ca5f7de285f84c9391R183-R187) to poll for a command's exit status alongside the usual expect checks. A helper function that returns a channel is used to facilitate use inside `select{}` statements (https://github.com/ActiveState/termtest/pull/12/files#diff-296a01a801f363652ec765418086e861f5db0287df573d54c8fde4eebe0e26e9R43).

https://github.com/ActiveState/cli/pull/3309 uses this PR's commit when running integration tests for State Tool to verify that it doesn't break anything at least.